### PR TITLE
Defaults to use ip address for geolocation if no params are given

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,9 +1,21 @@
 var getWeather = require('../services/getWeather');
 var Controller = {};
 var Async = require('async');
+var geoip = require('geoip-lite');
 
 Controller.index = function(req, response) {
-  var params = req.query;
+  var params = getParams();
+
+  function getParams() {
+    if(req.query.lat !== undefined && req.query.lon !== undefined) {
+      return req.query;
+    } else {
+        var ip  = '67.177.208.157'; // just a static IP for now
+        var geo = geoip.lookup(ip)['ll'];
+        
+        return { 'lat': geo[0], 'lon': geo[1] };
+      }
+  }
 
   Async.series([
     function(callback) {

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,37 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/local/bin/iojs', '/usr/local/bin/npm', 'start' ]
+2 info using npm@2.7.1
+3 info using node@v1.6.0
+4 verbose run-script [ 'prestart', 'start', 'poststart' ]
+5 info prestart forecastr@1.0.0
+6 info start forecastr@1.0.0
+7 verbose unsafe-perm in lifecycle true
+8 info forecastr@1.0.0 Failed to exec start script
+9 verbose stack Error: forecastr@1.0.0 start: `node index.js`
+9 verbose stack Exit status 1
+9 verbose stack     at EventEmitter.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/lifecycle.js:213:16)
+9 verbose stack     at emitTwo (events.js:87:13)
+9 verbose stack     at EventEmitter.emit (events.js:169:7)
+9 verbose stack     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/spawn.js:14:12)
+9 verbose stack     at emitTwo (events.js:87:13)
+9 verbose stack     at ChildProcess.emit (events.js:169:7)
+9 verbose stack     at maybeClose (child_process.js:984:16)
+9 verbose stack     at Process.ChildProcess._handle.onexit (child_process.js:1057:5)
+10 verbose pkgid forecastr@1.0.0
+11 verbose cwd /Users/alan.smith/personal_projects/js/forecastr
+12 error Darwin 14.1.0
+13 error argv "/usr/local/bin/iojs" "/usr/local/bin/npm" "start"
+14 error node v1.6.0
+15 error npm  v2.7.1
+16 error code ELIFECYCLE
+17 error forecastr@1.0.0 start: `node index.js`
+17 error Exit status 1
+18 error Failed at the forecastr@1.0.0 start script 'node index.js'.
+18 error This is most likely a problem with the forecastr package,
+18 error not with npm itself.
+18 error Tell the author that this fails on your system:
+18 error     node index.js
+18 error You can get their info via:
+18 error     npm owner ls forecastr
+18 error There is likely additional logging output above.
+19 verbose exit [ 1, true ]


### PR DESCRIPTION
I added some logic to grab lat & long from an IP address if the query params aren't available. I saw some information on getting the IP address from the request, but couldn't get it to work locally. The link for the stackoverflow issue I was looking at is [here](http://stackoverflow.com/questions/10849687/express-js-how-to-get-remote-client-address).

Maybe I'm missing something?

The current implementation uses a static IP, and works fine using the [node-geoip module](https://github.com/bluesmoon/node-geoip). It shouldn't be too much work to get it working dynamically.

The `[ll]` in the `geoip.lookup(ip)['ll']` is an array with the lat/long. I had to alter it in the `return` for it to be in the right format.
